### PR TITLE
Register tasks async and save Promise openportPromise into grunt.option

### DIFF
--- a/tasks/openport.js
+++ b/tasks/openport.js
@@ -1,44 +1,54 @@
 module.exports = function(grunt) {
   var openport = require('openport');
 
-  grunt.registerTask('openport', 'Finds an open port', function(target, start, end) {
-    var done = this.async();
-    target = target || 'port';
-    function callback(err, port) {
-      if (err) grunt.log.error(err);
-      else {
-        grunt.log.ok('Found open port: ' + port);
-        grunt.config(target, port);
-        done();
+  // Only supports a single call atm
+  grunt.option('openportPromise', new Promise(function(resolve, reject) {
+    grunt.registerTask('openport', 'Finds an open port', function(target, start, end) {
+      var done = this.async();
+      target = target || 'port';
+      function callback(err, port) {
+        if (err) {
+          grunt.log.error(err);
+          reject(err);
+        } else {
+          grunt.log.ok('Found open port: ' + port);
+          grunt.config(target, port);
+          done();
+          resolve(port);
+        }
       }
-    }
-    if (start) {
-      openport.find({startingPort:start,endingPort:end}, callback);
-    } else {
-      openport.find(callback);
-    }
-  });
-
-  grunt.registerTask('openports', 'Finds open ports', function() {
-    var done = this.async();
-    var ports = Array.prototype.slice.call(arguments);
-    var target = ports.shift();
-    var count = Number(ports.pop());
-    ports = ports.map(Number);
-
-    if (count >= ports.length) {
-      ports.push(count);
-      count = ports.length - 1;
-    }
-
-    openport.find({ports:ports,count:count}, function(err, ports) {
-      if (err) grunt.log.error(err);
-      else {
-        if (!Array.isArray(ports)) ports = [ports];
-        grunt.log.ok('Found ' + count + ' open port(s): ' + ports.join(','));
-        grunt.config(target, ports);
-        done();
+      if (start) {
+        openport.find({startingPort:start,endingPort:end}, callback);
+      } else {
+        openport.find(callback);
       }
     });
-  });
+
+    grunt.registerTask('openports', 'Finds open ports', function() {
+      var done = this.async();
+      var ports = Array.prototype.slice.call(arguments);
+      var target = ports.shift();
+      var count = Number(ports.pop());
+      ports = ports.map(Number);
+
+      if (count >= ports.length) {
+        ports.push(count);
+        count = ports.length - 1;
+      }
+
+      openport.find({ports:ports,count:count}, function(err, ports) {
+        if (err){
+          grunt.log.error(err); 
+          reject(err);
+        }
+        else {
+          if (!Array.isArray(ports)) ports = [ports];
+          grunt.log.ok('Found ' + count + ' open port(s): ' + ports.join(','));
+          grunt.config(target, ports);
+          done();
+          resolve(ports);
+        }
+      });
+    });
+  }));
 };


### PR DESCRIPTION
to allow initConfig to be executed after the Promise resolves. This is
needed by grunt libraries like load-grunt-config where the config is
loaded before the openport tasks completes. Using openport's specific
task overrides is insufficient as sometimes tasks use the port to do
internal configuration.

An example of this in use in a clean Gruntfile.js:

```
module.exports = function(grunt) {
  require('jit-grunt')(grunt);
  require('time-grunt')(grunt);
  grunt.loadNpmTasks('grunt-openport');
  grunt.task.run('openport:port:10000');
  grunt.option('openportPromise').then(() => {
    require('load-grunt-config')(grunt, {
      jitGrunt: true
    });
  });
};
```

Let me know if you any other ideas on achieving something this.

Use this link to ignore whitespace: https://github.com/talee/grunt-openport/commit/27248d870a6f5b0cc87953abaff1ae8da96be32a?w=1
